### PR TITLE
Disable schema sync in bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "strapi",
+  "version": "4.17.2",
   "private": true,
   "bugs": {
     "url": "https://github.com/strapi/strapi/issues"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/strapi/strapi.git"
+    "url": "git://github.com/HealthLearn/strapi.git"
   },
   "license": "SEE LICENSE IN LICENSE",
   "author": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@babel/eslint-parser": "^7.19.1",
     "@babel/preset-react": "7.18.6",
     "@playwright/test": "1.38.1",
-    "@strapi/admin-test-utils": "workspace:*",
+    "@strapi/admin-test-utils": "4.17.0",
     "@strapi/eslint-config": "0.2.0",
     "@swc/cli": "0.1.62",
     "@swc/core": "1.3.58",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi",
-  "version": "4.17.2",
+  "version": "4.17.0",
   "private": true,
   "bugs": {
     "url": "https://github.com/strapi/strapi/issues"

--- a/packages/admin-test-utils/package.json
+++ b/packages/admin-test-utils/package.json
@@ -72,7 +72,7 @@
   },
   "devDependencies": {
     "@reduxjs/toolkit": "1.9.7",
-    "@strapi/pack-up": "workspace:*",
+    "@strapi/pack-up": "4.17.0",
     "@testing-library/jest-dom": "5.16.5",
     "eslint-config-custom": "4.17.0",
     "tsconfig": "4.17.0"

--- a/packages/core/content-manager/package.json
+++ b/packages/core/content-manager/package.json
@@ -57,7 +57,7 @@
     "qs": "6.11.1"
   },
   "devDependencies": {
-    "@strapi/pack-up": "workspace:*",
+    "@strapi/pack-up": "4.17.0",
     "@types/jest": "29.5.2",
     "@types/lodash": "^4.14.191"
   },

--- a/packages/core/content-releases/package.json
+++ b/packages/core/content-releases/package.json
@@ -59,7 +59,7 @@
     "@strapi/design-system": "1.14.1",
     "@strapi/helper-plugin": "4.17.0",
     "@strapi/icons": "1.14.1",
-    "@strapi/types": "workspace:*",
+    "@strapi/types": "4.17.0",
     "@strapi/utils": "4.17.0",
     "axios": "1.6.0",
     "formik": "2.4.0",
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@strapi/admin-test-utils": "4.17.0",
-    "@strapi/pack-up": "workspace:*",
+    "@strapi/pack-up": "4.17.0",
     "@strapi/strapi": "4.17.0",
     "@testing-library/react": "14.0.0",
     "@testing-library/user-event": "14.4.3",

--- a/packages/core/strapi/package.json
+++ b/packages/core/strapi/package.json
@@ -175,7 +175,7 @@
     "yup": "0.32.9"
   },
   "devDependencies": {
-    "@strapi/pack-up": "workspace:*",
+    "@strapi/pack-up": "4.17.0",
     "@strapi/ts-zen": "^0.2.0",
     "@types/bcryptjs": "2.4.3",
     "@types/configstore": "5.0.1",

--- a/packages/core/strapi/src/Strapi.ts
+++ b/packages/core/strapi/src/Strapi.ts
@@ -591,7 +591,7 @@ class Strapi implements StrapiI {
       contentTypes: this.contentTypes,
     });
 
-    await this.db.schema.sync();
+    // await this.db.schema.sync();
 
     if (this.EE) {
       await ee.checkLicense({ strapi: this });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7517,13 +7517,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/admin-test-utils@npm:4.17.0, @strapi/admin-test-utils@workspace:*, @strapi/admin-test-utils@workspace:packages/admin-test-utils":
+"@strapi/admin-test-utils@npm:4.17.0, @strapi/admin-test-utils@4.17.0, @strapi/admin-test-utils@workspace:packages/admin-test-utils":
   version: 0.0.0-use.local
   resolution: "@strapi/admin-test-utils@workspace:packages/admin-test-utils"
   dependencies:
     "@juggle/resize-observer": "npm:3.4.0"
     "@reduxjs/toolkit": "npm:1.9.7"
-    "@strapi/pack-up": "workspace:*"
+    "@strapi/pack-up": "4.17.0"
     "@testing-library/jest-dom": "npm:5.16.5"
     eslint-config-custom: "npm:4.17.0"
     jest-styled-components: "npm:7.1.1"
@@ -7687,9 +7687,9 @@ __metadata:
     "@strapi/design-system": "npm:1.14.1"
     "@strapi/helper-plugin": "npm:4.17.0"
     "@strapi/icons": "npm:1.14.1"
-    "@strapi/pack-up": "workspace:*"
+    "@strapi/pack-up": "4.17.0"
     "@strapi/strapi": "npm:4.17.0"
-    "@strapi/types": "workspace:*"
+    "@strapi/types": "4.17.0"
     "@strapi/utils": "npm:4.17.0"
     "@testing-library/react": "npm:14.0.0"
     "@testing-library/user-event": "npm:14.4.3"
@@ -7946,7 +7946,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@strapi/pack-up@npm:4.17.0, @strapi/pack-up@workspace:*, @strapi/pack-up@workspace:packages/utils/pack-up":
+"@strapi/pack-up@npm:4.17.0, @strapi/pack-up@4.17.0, @strapi/pack-up@workspace:packages/utils/pack-up":
   version: 0.0.0-use.local
   resolution: "@strapi/pack-up@workspace:packages/utils/pack-up"
   dependencies:
@@ -8059,7 +8059,7 @@ __metadata:
   resolution: "@strapi/plugin-content-manager@workspace:packages/core/content-manager"
   dependencies:
     "@sindresorhus/slugify": "npm:1.1.0"
-    "@strapi/pack-up": "workspace:*"
+    "@strapi/pack-up": "4.17.0"
     "@strapi/types": "npm:4.17.0"
     "@strapi/utils": "npm:4.17.0"
     "@types/jest": "npm:29.5.2"
@@ -8516,7 +8516,7 @@ __metadata:
     "@strapi/generate-new": "npm:4.17.0"
     "@strapi/generators": "npm:4.17.0"
     "@strapi/logger": "npm:4.17.0"
-    "@strapi/pack-up": "workspace:*"
+    "@strapi/pack-up": "4.17.0"
     "@strapi/permissions": "npm:4.17.0"
     "@strapi/plugin-content-manager": "npm:4.17.0"
     "@strapi/plugin-content-type-builder": "npm:4.17.0"
@@ -8602,7 +8602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@strapi/types@npm:4.17.0, @strapi/types@workspace:*, @strapi/types@workspace:packages/core/types":
+"@strapi/types@npm:4.17.0, @strapi/types@4.17.0, @strapi/types@workspace:packages/core/types":
   version: 0.0.0-use.local
   resolution: "@strapi/types@workspace:packages/core/types"
   dependencies:
@@ -27916,7 +27916,7 @@ __metadata:
     "@babel/eslint-parser": "npm:^7.19.1"
     "@babel/preset-react": "npm:7.18.6"
     "@playwright/test": "npm:1.38.1"
-    "@strapi/admin-test-utils": "workspace:*"
+    "@strapi/admin-test-utils": "4.17.0"
     "@strapi/eslint-config": "npm:0.2.0"
     "@swc/cli": "npm:0.1.62"
     "@swc/core": "npm:1.3.58"


### PR DESCRIPTION
Allows strapi to start without trying to match schemas, which are now controlled elsewhere.

Note: I didn't actually get this working